### PR TITLE
AOP2-56: Store council/agency domain instead of name in referral

### DIFF
--- a/backend/DB/migration/pending/2-recreate-govdomains-view.sql
+++ b/backend/DB/migration/pending/2-recreate-govdomains-view.sql
@@ -1,0 +1,7 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE IF EXISTS "public"."referral" DROP COLUMN IF EXISTS agency_name;
+
+ALTER TABLE IF EXISTS "public"."referral" ADD COLUMN IF NOT EXISTS "domain" character varying not null;
+
+COMMIT;

--- a/backend/app/api/services/referrals.py
+++ b/backend/app/api/services/referrals.py
@@ -1,6 +1,5 @@
 from app.api.helpers import Service, get_email_domain
 from app.models import Referral
-from .users import UsersService
 
 
 class ReferralService(Service):
@@ -8,10 +7,8 @@ class ReferralService(Service):
 
     def __init__(self, *args, **kwargs):
         super(ReferralService, self).__init__(*args, **kwargs)
-        self.user_service = UsersService()
 
     def create_referral(self, service_type_price_id, requested_by):
-        user_org = self.user_service.get_user_organisation(get_email_domain(requested_by.email_address))
         return self.create(service_type_price_id=service_type_price_id,
-                           agency_name=user_org,
+                           domain=get_email_domain(requested_by.email_address),
                            created_by=requested_by.id)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2845,7 +2845,8 @@ class Referral(db.Model):
     service_type_price_id = db.Column(db.Integer,
                                       db.ForeignKey('service_type_price.id'),
                                       nullable=False)
-    agency_name = db.Column(db.String, nullable=False)
+
+    domain = db.Column(db.String, nullable=False)
     created_by = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     created_at = db.Column(DateTime, index=False, nullable=False, default=utcnow)
 

--- a/backend/tests/fixtures/test_referrals.py
+++ b/backend/tests/fixtures/test_referrals.py
@@ -47,7 +47,7 @@ def test_referral_created(client, users, agencies, service_prices_without_future
     referral = Referral.query\
         .filter(Referral.id == referral['referralId'])\
         .first()
-    assert referral.agency_name == 'Digital Transformation Agency'
+    assert referral.domain == 'digital.gov.au'
     assert referral.created_by == buyer.id
     assert referral.service_type_price.supplier_code == service_prices_without_future[0].supplier_code
     assert referral.service_type_price.price == service_prices_without_future[0].price


### PR DESCRIPTION
Storing the domain will give us more confidence in validating users that are attempting to retreive a referral.

- on retrieval, validation can be done against the requestor's domain
- on retrieval, we can lookup the name associated with a domain in govdomains
- on storage, we store the requestor's domain